### PR TITLE
filecount: Controls whether or not to include only regular files in the count

### DIFF
--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -601,7 +601,7 @@
 #		Size "+10k"
 #		Recursive true
 #		IncludeHidden false
-#		IncludeOnlyRegular true
+#		RegularOnly true
 #		#FilesSizeType "bytes"
 #		#FilesCountType "files"
 #		#TypeInstance "instance"

--- a/src/collectd.conf.in
+++ b/src/collectd.conf.in
@@ -601,6 +601,7 @@
 #		Size "+10k"
 #		Recursive true
 #		IncludeHidden false
+#		IncludeOnlyRegular true
 #		#FilesSizeType "bytes"
 #		#FilesCountType "files"
 #		#TypeInstance "instance"

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2657,6 +2657,11 @@ this many threads will be started immediately setting this to a very high
 value will waste valuable resources. Defaults to B<5> and will be forced to be
 at most B<16384> to prevent typos and dumb mistakes.
 
+=item B<IncludeOnlyRegular> I<true>|I<false>
+
+Controls whether or not to include only regular files in the count.
+Defaults to I<true>, i.e. by default non regular files are ignored.
+
 =back
 
 =head2 Plugin C<ethstat>

--- a/src/collectd.conf.pod
+++ b/src/collectd.conf.pod
@@ -2657,11 +2657,6 @@ this many threads will be started immediately setting this to a very high
 value will waste valuable resources. Defaults to B<5> and will be forced to be
 at most B<16384> to prevent typos and dumb mistakes.
 
-=item B<IncludeOnlyRegular> I<true>|I<false>
-
-Controls whether or not to include only regular files in the count.
-Defaults to I<true>, i.e. by default non regular files are ignored.
-
 =back
 
 =head2 Plugin C<ethstat>
@@ -2838,6 +2833,11 @@ Controls whether or not to recurse into subdirectories. Enabled by default.
 Controls whether or not to include "hidden" files and directories in the count.
 "Hidden" files and directories are those, whose name begins with a dot.
 Defaults to I<false>, i.e. by default hidden files and directories are ignored.
+
+=item B<RegularOnly> I<true>|I<false>
+
+Controls whether or not to include only regular files in the count.
+Defaults to I<true>, i.e. by default non regular files are ignored.
 
 =item B<FilesSizeType> I<Type>
 

--- a/src/filecount.c
+++ b/src/filecount.c
@@ -34,6 +34,7 @@
 
 #define FC_RECURSIVE 1
 #define FC_HIDDEN 2
+#define FC_REGULAR 4
 
 struct fc_directory_conf_s {
   char *path;
@@ -340,7 +341,7 @@ static int fc_config_add_dir(oconfig_item_t *ci) {
     return -1;
   }
 
-  dir->options = FC_RECURSIVE;
+  dir->options = FC_RECURSIVE | FC_REGULAR;
 
   dir->name = NULL;
   dir->plugin_name = strdup("filecount");
@@ -377,6 +378,8 @@ static int fc_config_add_dir(oconfig_item_t *ci) {
       status = fc_config_add_dir_option(dir, option, FC_RECURSIVE);
     else if (strcasecmp("IncludeHidden", option->key) == 0)
       status = fc_config_add_dir_option(dir, option, FC_HIDDEN);
+    else if (strcasecmp("IncludeOnlyRegular", option->key) == 0)
+      status = fc_config_add_dir_option(dir, option, FC_REGULAR);
     else if (strcasecmp("FilesSizeType", option->key) == 0)
       status = cf_util_get_string(option, &dir->files_size_type);
     else if (strcasecmp("FilesCountType", option->key) == 0)
@@ -488,7 +491,7 @@ static int fc_read_dir_callback(const char *dirname, const char *filename,
         abs_path, fc_read_dir_callback, dir,
         /* include hidden = */ (dir->options & FC_HIDDEN) ? 1 : 0);
     return status;
-  } else if (!S_ISREG(statbuf.st_mode)) {
+  } else if ((dir->options & FC_REGULAR) && !S_ISREG(statbuf.st_mode)) {
     return 0;
   }
 
@@ -498,37 +501,40 @@ static int fc_read_dir_callback(const char *dirname, const char *filename,
       return 0;
   }
 
-  if (dir->mtime != 0) {
-    time_t mtime = dir->now;
+  if (S_ISREG(statbuf.st_mode)) {
+    if (dir->mtime != 0) {
+      time_t mtime = dir->now;
 
-    if (dir->mtime < 0)
-      mtime += dir->mtime;
-    else
-      mtime -= dir->mtime;
+      if (dir->mtime < 0)
+        mtime += dir->mtime;
+      else
+        mtime -= dir->mtime;
 
-    DEBUG("filecount plugin: Only collecting files that were touched %s %u.",
-          (dir->mtime < 0) ? "after" : "before", (unsigned int)mtime);
+      DEBUG("filecount plugin: Only collecting files that were touched %s %u.",
+            (dir->mtime < 0) ? "after" : "before", (unsigned int)mtime);
 
-    if (((dir->mtime < 0) && (statbuf.st_mtime < mtime)) ||
-        ((dir->mtime > 0) && (statbuf.st_mtime > mtime)))
-      return 0;
-  }
+      if (((dir->mtime < 0) && (statbuf.st_mtime < mtime)) ||
+          ((dir->mtime > 0) && (statbuf.st_mtime > mtime)))
+        return 0;
+    }
 
-  if (dir->size != 0) {
-    off_t size;
+    if (dir->size != 0) {
+      off_t size;
 
-    if (dir->size < 0)
-      size = (off_t)((-1) * dir->size);
-    else
-      size = (off_t)dir->size;
+      if (dir->size < 0)
+        size = (off_t)((-1) * dir->size);
+      else
+        size = (off_t)dir->size;
 
-    if (((dir->size < 0) && (statbuf.st_size > size)) ||
-        ((dir->size > 0) && (statbuf.st_size < size)))
-      return 0;
+      if (((dir->size < 0) && (statbuf.st_size > size)) ||
+          ((dir->size > 0) && (statbuf.st_size < size)))
+        return 0;
+    }
+
+    dir->files_size += (uint64_t)statbuf.st_size;
   }
 
   dir->files_num++;
-  dir->files_size += (uint64_t)statbuf.st_size;
 
   return 0;
 } /* int fc_read_dir_callback */


### PR DESCRIPTION
The new option 'IncludeOnlyRegular' added to have possibility count the
files on '/proc' or '/sys'